### PR TITLE
Include support Seagate Barracuda Pro Compute (Data recovery services)

### DIFF
--- a/smartmontools/drivedb.h
+++ b/smartmontools/drivedb.h
@@ -2727,9 +2727,13 @@ const drive_settings builtin_knowndrives[] = {
     "ST(250|320|500|640|750|1000)LM0[012][3459] HN-M[0-9]*ABB",
     "", "", ""
   },
-  { "Seagate Barracuda Pro Compute", // tested with ST1000LM049-2GH172/SDM1
+  { "Seagate Barracuda Pro Compute (Standard models)", // tested with ST1000LM049-2GH172/SDM1
     "ST(1000LM049|500LM034)-.*",
     "", "", ""
+  },
+  { "Seagate Barracuda Pro Compute (Data recovery services)", // tested with ST8000DM0004-1ZC11G/DN01
+      "ST(8|10|12)000DM000[47]-.*",
+      "", "", ""
   },
   { "Seagate Samsung SpinPoint M9T", // tested with ST2000LM003 HN-M201RAD/2BC10003
       // (Seagate Expansion Portable)


### PR DESCRIPTION
Change spec for old models

Docs form Barracuda Pro models
https://www.seagate.com/www-content/product-content/barracuda-fam/barracuda-new/en-us/docs/100818004d.pdf
https://www.seagate.com/files/www-content/product-content/seagate-laptop-fam/barracuda_25/en-us/docs/100818135e.pdf

<pre>
smartctl 7.1 2019-12-30 r5022 [x86_64-linux-4.19.110-gentoo] (local build)
Copyright (C) 2002-19, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Model Family:     Seagate Barracuda Pro Compute (Data recovery services)
Device Model:     ST8000DM0004-1ZC11G
Serial Number:    ZA26CA7Q
LU WWN Device Id: 5 000c50 0b0ca49a0
Firmware Version: DN01
User Capacity:    8.001.563.222.016 bytes [8,00 TB]
Sector Sizes:     512 bytes logical, 4096 bytes physical
Rotation Rate:    7200 rpm
Form Factor:      3.5 inches
Device is:        In smartctl database [for details use: -P show]
ATA Version is:   ACS-3 T13/2161-D revision 5
SATA Version is:  SATA 3.1, 6.0 Gb/s (current: 6.0 Gb/s)
Local Time is:    Tue Nov 17 19:46:57 2020 CET
SMART support is: Available - device has SMART capability.
SMART support is: Enabled
AAM feature is:   Unavailable
APM feature is:   Unavailable
Rd look-ahead is: Enabled
Write cache is:   Enabled
DSN feature is:   Unavailable
ATA Security is:  Disabled, NOT FROZEN [SEC1]
Wt Cache Reorder: Enabled

=== START OF READ SMART DATA SECTION ===
SMART overall-health self-assessment test result: PASSED
See vendor-specific Attribute list for marginal Attributes.

General SMART Values:
Offline data collection status:  (0x82) Offline data collection activity
                                        was completed without error.
                                        Auto Offline Data Collection: Enabled.
Self-test execution status:      (   0) The previous self-test routine completed
                                        without error or no self-test has ever 
                                        been run.
Total time to complete Offline 
data collection:                (  584) seconds.
Offline data collection
capabilities:                    (0x7b) SMART execute Offline immediate.
                                        Auto Offline data collection on/off support.
                                        Suspend Offline collection upon new
                                        command.
                                        Offline surface scan supported.
                                        Self-test supported.
                                        Conveyance Self-test supported.
                                        Selective Self-test supported.
SMART capabilities:            (0x0003) Saves SMART data before entering
                                        power-saving mode.
                                        Supports SMART auto save timer.
Error logging capability:        (0x01) Error logging supported.
                                        General Purpose Logging supported.
Short self-test routine 
recommended polling time:        (   1) minutes.
Extended self-test routine
recommended polling time:        ( 729) minutes.
Conveyance self-test routine
recommended polling time:        (   2) minutes.
SCT capabilities:              (0x50bd) SCT Status supported.
                                        SCT Error Recovery Control supported.
                                        SCT Feature Control supported.
                                        SCT Data Table supported.

SMART Attributes Data Structure revision number: 10
Vendor Specific SMART Attributes with Thresholds:
ID# ATTRIBUTE_NAME          FLAGS    VALUE WORST THRESH FAIL RAW_VALUE
  1 Raw_Read_Error_Rate     POSR--   081   064   044    -    120635030
  3 Spin_Up_Time            PO----   090   089   000    -    0
  4 Start_Stop_Count        -O--CK   100   100   020    -    86
  5 Reallocated_Sector_Ct   PO--CK   100   100   010    -    0
  7 Seek_Error_Rate         POSR--   089   060   045    -    864230513
  9 Power_On_Hours          -O--CK   081   081   000    -    16807 (253 143 0)
 10 Spin_Retry_Count        PO--C-   100   095   097    Past 0
 12 Power_Cycle_Count       -O--CK   100   100   020    -    83
184 End-to-End_Error        -O--CK   100   100   099    -    0
187 Reported_Uncorrect      -O--CK   100   100   000    -    0
188 Command_Timeout         -O--CK   100   099   000    -    8590065666
189 High_Fly_Writes         -O-RCK   076   076   000    -    24
190 Airflow_Temperature_Cel -O---K   071   044   040    -    29 (Min/Max 26/37)
191 G-Sense_Error_Rate      -O--CK   064   064   000    -    73139
192 Power-Off_Retract_Count -O--CK   100   100   000    -    24
193 Load_Cycle_Count        -O--CK   088   088   000    -    24901
194 Temperature_Celsius     -O---K   029   056   000    -    29 (0 20 0 0 0)
195 Hardware_ECC_Recovered  -O-RC-   001   001   000    -    120635030
197 Current_Pending_Sector  -O--C-   100   100   000    -    0
198 Offline_Uncorrectable   ----C-   100   100   000    -    0
199 UDMA_CRC_Error_Count    -OSRCK   200   200   000    -    0
200 Multi_Zone_Error_Rate   PO---K   100   100   001    -    0
240 Head_Flying_Hours       ------   100   253   000    -    4482 (35 110 0)
241 Total_LBAs_Written      ------   100   253   000    -    46475212010
242 Total_LBAs_Read         ------   100   253   000    -    95808430544
                            ||||||_ K auto-keep
                            |||||__ C event count
                            ||||___ R error rate
                            |||____ S speed/performance
                            ||_____ O updated online
                            |______ P prefailure warning

General Purpose Log Directory Version 1
SMART           Log Directory Version 1 [multi-sector log support]
Address    Access  R/W   Size  Description
0x00       GPL,SL  R/O      1  Log Directory
0x01           SL  R/O      1  Summary SMART error log
0x02           SL  R/O      5  Comprehensive SMART error log
0x03       GPL     R/O      5  Ext. Comprehensive SMART error log
0x04       GPL     R/O    256  Device Statistics log
0x04       SL      R/O      8  Device Statistics log
0x06           SL  R/O      1  SMART self-test log
0x07       GPL     R/O      1  Extended self-test log
0x08       GPL     R/O      2  Power Conditions log
0x09           SL  R/W      1  Selective self-test log
0x0c       GPL     R/O   2048  Pending Defects log
0x10       GPL     R/O      1  NCQ Command Error log
0x11       GPL     R/O      1  SATA Phy Event Counters log
0x13       GPL     R/O      1  SATA NCQ Send and Receive log
0x15       GPL     R/W      1  Rebuild Assist log
0x21       GPL     R/O      1  Write stream error log
0x22       GPL     R/O      1  Read stream error log
0x24       GPL     R/O    768  Current Device Internal Status Data log
0x30       GPL,SL  R/O      9  IDENTIFY DEVICE data log
0x80-0x9f  GPL,SL  R/W     16  Host vendor specific log
0xa1       GPL,SL  VS      24  Device vendor specific log
0xa2       GPL     VS   16320  Device vendor specific log
0xa6       GPL     VS     192  Device vendor specific log
0xa8-0xa9  GPL,SL  VS     136  Device vendor specific log
0xab       GPL     VS       1  Device vendor specific log
0xad       GPL     VS      16  Device vendor specific log
0xb0       GPL     VS   17208  Device vendor specific log
0xbe-0xbf  GPL     VS   65535  Device vendor specific log
0xc1       GPL,SL  VS      16  Device vendor specific log
0xc3       GPL,SL  VS       8  Device vendor specific log
0xc9       GPL,SL  VS       8  Device vendor specific log
0xca       GPL,SL  VS      16  Device vendor specific log
0xd1       GPL     VS     304  Device vendor specific log
0xd2       GPL     VS   10000  Device vendor specific log
0xd4       GPL     VS    2048  Device vendor specific log
0xe0       GPL,SL  R/W      1  SCT Command/Status
0xe1       GPL,SL  R/W      1  SCT Data Transfer

SMART Extended Comprehensive Error Log Version: 1 (5 sectors)
No Errors Logged

SMART Extended Self-test Log Version: 1 (1 sectors)
Num  Test_Description    Status                  Remaining  LifeTime(hours)  LBA_of_first_error
# 1  Short offline       Completed without error       00%     16774         -
# 2  Short offline       Completed without error       00%     16774         -
# 3  Extended offline    Completed without error       00%      3988         -
# 4  Extended offline    Completed without error       00%      3915         -
# 5  Extended offline    Interrupted (host reset)      10%      3886         -
# 6  Short offline       Completed without error       00%      3871         -

SMART Selective self-test log data structure revision number 1
 SPAN  MIN_LBA  MAX_LBA  CURRENT_TEST_STATUS
    1        0        0  Not_testing
    2        0        0  Not_testing
    3        0        0  Not_testing
    4        0        0  Not_testing
    5        0        0  Not_testing
Selective self-test flags (0x0):
  After scanning selected spans, do NOT read-scan remainder of disk.
If Selective self-test is pending on power-up, resume after 0 minute delay.

SCT Status Version:                  3
SCT Version (vendor specific):       522 (0x020a)
Device State:                        Active (0)
Current Temperature:                    29 Celsius
Power Cycle Min/Max Temperature:     26/37 Celsius
Lifetime    Min/Max Temperature:     19/56 Celsius
Under/Over Temperature Limit Count:   0/1283

SCT Temperature History Version:     2
Temperature Sampling Period:         3 minutes
Temperature Logging Interval:        59 minutes
Min/Max recommended Temperature:      0/ 0 Celsius
Min/Max Temperature Limit:            0/ 0 Celsius
Temperature History Size (Index):    128 (24)

Index    Estimated Time   Temperature Celsius
  25    2020-11-12 14:37    32  *************
  26    2020-11-12 15:36    33  **************
  27    2020-11-12 16:35    33  **************
  28    2020-11-12 17:34    33  **************
  29    2020-11-12 18:33    31  ************
  30    2020-11-12 19:32    30  ***********
  31    2020-11-12 20:31    30  ***********
  32    2020-11-12 21:30    30  ***********
  33    2020-11-12 22:29    29  **********
  34    2020-11-12 23:28    29  **********
  35    2020-11-13 00:27    29  **********
  36    2020-11-13 01:26    28  *********
  37    2020-11-13 02:25    28  *********
  38    2020-11-13 03:24    31  ************
 ...    ..(  8 skipped).    ..  ************
  47    2020-11-13 12:15    31  ************
  48    2020-11-13 13:14    32  *************
  49    2020-11-13 14:13    32  *************
  50    2020-11-13 15:12    33  **************
  51    2020-11-13 16:11    33  **************
  52    2020-11-13 17:10    33  **************
  53    2020-11-13 18:09    31  ************
  54    2020-11-13 19:08    29  **********
 ...    ..(  2 skipped).    ..  **********
  57    2020-11-13 22:05    29  **********
  58    2020-11-13 23:04    28  *********
 ...    ..(  2 skipped).    ..  *********
  61    2020-11-14 02:01    28  *********
  62    2020-11-14 03:00    31  ************
 ...    ..(  4 skipped).    ..  ************
  67    2020-11-14 07:55    31  ************
  68    2020-11-14 08:54    30  ***********
 ...    ..(  2 skipped).    ..  ***********
  71    2020-11-14 11:51    30  ***********
  72    2020-11-14 12:50    31  ************
  73    2020-11-14 13:49    31  ************
  74    2020-11-14 14:48    31  ************
  75    2020-11-14 15:47    32  *************
  76    2020-11-14 16:46    29  **********
  77    2020-11-14 17:45    29  **********
  78    2020-11-14 18:44    28  *********
 ...    ..(  6 skipped).    ..  *********
  85    2020-11-15 01:37    28  *********
  86    2020-11-15 02:36    31  ************
  87    2020-11-15 03:35    31  ************
  88    2020-11-15 04:34    30  ***********
 ...    ..(  4 skipped).    ..  ***********
  93    2020-11-15 09:29    30  ***********
  94    2020-11-15 10:28    29  **********
  95    2020-11-15 11:27    30  ***********
  96    2020-11-15 12:26    28  *********
  97    2020-11-15 13:25    28  *********
  98    2020-11-15 14:24    28  *********
  99    2020-11-15 15:23    29  **********
 ...    ..(  8 skipped).    ..  **********
 108    2020-11-16 00:14    29  **********
 109    2020-11-16 01:13    28  *********
 110    2020-11-16 02:12    32  *************
 111    2020-11-16 03:11    31  ************
 112    2020-11-16 04:10    31  ************
 113    2020-11-16 05:09    31  ************
 114    2020-11-16 06:08    32  *************
 115    2020-11-16 07:07    29  **********
 116    2020-11-16 08:06    29  **********
 117    2020-11-16 09:05    28  *********
 118    2020-11-16 10:04    29  **********
 119    2020-11-16 11:03    29  **********
 120    2020-11-16 12:02    30  ***********
 ...    ..(  5 skipped).    ..  ***********
 126    2020-11-16 17:56    30  ***********
 127    2020-11-16 18:55    29  **********
   0    2020-11-16 19:54    29  **********
   1    2020-11-16 20:53    30  ***********
   2    2020-11-16 21:52    30  ***********
   3    2020-11-16 22:51    30  ***********
   4    2020-11-16 23:50    29  **********
   5    2020-11-17 00:49    29  **********
   6    2020-11-17 01:48    32  *************
 ...    ..(  3 skipped).    ..  *************
  10    2020-11-17 05:44    32  *************
  11    2020-11-17 06:43    31  ************
  12    2020-11-17 07:42    31  ************
  13    2020-11-17 08:41    31  ************
  14    2020-11-17 09:40    32  *************
  15    2020-11-17 10:39    32  *************
  16    2020-11-17 11:38    33  **************
  17    2020-11-17 12:37    30  ***********
 ...    ..(  5 skipped).    ..  ***********
  23    2020-11-17 18:31    30  ***********
  24    2020-11-17 19:30    29  **********

SCT Error Recovery Control:
           Read:     70 (7,0 seconds)
          Write:     70 (7,0 seconds)

Device Statistics (GP Log 0x04)
Page  Offset Size        Value Flags Description
0x01  =====  =               =  ===  == General Statistics (rev 1) ==
0x01  0x008  4              83  ---  Lifetime Power-On Resets
0x01  0x010  4           16807  ---  Power-on Hours
0x01  0x018  6     46478037492  ---  Logical Sectors Written
0x01  0x020  6       120814107  ---  Number of Write Commands
0x01  0x028  6     95836339391  ---  Logical Sectors Read
0x01  0x030  6       159709302  ---  Number of Read Commands
0x01  0x038  6               -  ---  Date and Time TimeStamp
0x03  =====  =               =  ===  == Rotating Media Statistics (rev 1) ==
0x03  0x008  4      1117029438  N--  Spindle Motor Power-on Hours
0x03  0x010  4      1117013477  N--  Head Flying Hours
0x03  0x018  4           24901  ---  Head Load Events
0x03  0x020  4               0  ---  Number of Reallocated Logical Sectors
0x03  0x028  4               0  ---  Read Recovery Attempts
0x03  0x030  4              42  ---  Number of Mechanical Start Failures
0x03  0x038  4               0  ---  Number of Realloc. Candidate Logical Sectors
0x03  0x040  4              24  ---  Number of High Priority Unload Events
0x04  =====  =               =  ===  == General Errors Statistics (rev 1) ==
0x04  0x008  4               0  ---  Number of Reported Uncorrectable Errors
0x04  0x010  4               2  ---  Resets Between Cmd Acceptance and Completion
0x05  =====  =               =  ===  == Temperature Statistics (rev 1) ==
0x05  0x008  1              29  ---  Current Temperature
0x05  0x010  1              30  ---  Average Short Term Temperature
0x05  0x018  1              30  ---  Average Long Term Temperature
0x05  0x020  1              56  ---  Highest Temperature
0x05  0x028  1               0  ---  Lowest Temperature
0x05  0x030  1              53  ---  Highest Average Short Term Temperature
0x05  0x038  1              24  ---  Lowest Average Short Term Temperature
0x05  0x040  1              48  ---  Highest Average Long Term Temperature
0x05  0x048  1              27  ---  Lowest Average Long Term Temperature
0x05  0x050  4               0  ---  Time in Over-Temperature
0x05  0x058  1              60  ---  Specified Maximum Operating Temperature
0x05  0x060  4              80  ---  Time in Under-Temperature
0x05  0x068  1               5  ---  Specified Minimum Operating Temperature
0x06  =====  =               =  ===  == Transport Statistics (rev 1) ==
0x06  0x008  4            1037  ---  Number of Hardware Resets
0x06  0x010  4             435  ---  Number of ASR Events
0x06  0x018  4               0  ---  Number of Interface CRC Errors
0xff  =====  =               =  ===  == Vendor Specific Statistics (rev 1) ==
0xff  0x008  7               0  ---  Vendor Specific
                                |||_ C monitored condition met
                                ||__ D supports DSN
                                |___ N normalized value

Pending Defects log (GP Log 0x0c)
No Defects Logged

SATA Phy Event Counters (GP Log 0x11)
ID      Size     Value  Description
0x000a  2           45  Device-to-host register FISes sent due to a COMRESET
0x0001  2            0  Command failed due to ICRC error
0x0003  2            0  R_ERR response for device-to-host data FIS
0x0004  2            0  R_ERR response for host-to-device data FIS
0x0006  2            0  R_ERR response for device-to-host non-data FIS
0x0007  2            0  R_ERR response for host-to-device non-data FIS
</pre>